### PR TITLE
delay module unloading

### DIFF
--- a/zend/StandardModule.php
+++ b/zend/StandardModule.php
@@ -579,9 +579,9 @@ if (!\class_exists('StandardModule')) {
             }
 
             if ($this->r_shutdown)
-                \register_shutdown_function(
-                    \closure_from($this, 'module_destructor')
-                );
+                \register_shutdown_function(function () {
+                    \register_shutdown_function(\closure_from($this, 'module_destructor'));
+                });
 
 
             if ($this->restart_sapi) {

--- a/zend/ThreadsModule.php
+++ b/zend/ThreadsModule.php
@@ -116,9 +116,9 @@ if (\PHP_ZTS && !\class_exists('ThreadsModule')) {
             }
 
             if ($this->r_shutdown)
-                \register_shutdown_function(
-                    \closure_from($this, 'module_destructor')
-                );
+                \register_shutdown_function(function () {
+                    \register_shutdown_function(\closure_from($this, 'module_destructor'));
+                });
 
             $result = \IS_PHP82
                 ? \ze_ffi()->php_module_startup(\FFI::addr(\ze_ffi()->sapi_module), null)


### PR DESCRIPTION
Taking advantage of the ["reschedule" logic of `register_shutdown_function`](http://php.net/register_shutdown_function), specifically:

> Shutdown functions may also call register_shutdown_function() themselves to add a shutdown function to the end of the queue.

This avoids errors like:
> Uncaught TypeError: uv_ffi(): Return value must be of type FFI, null returned

I've encountered this issue when using the `symplely/uv-ffi` and had a wrapper that called `uv_run()` from a `register_shutdown_function` 